### PR TITLE
Exit with status 1 on error in main section

### DIFF
--- a/main.c
+++ b/main.c
@@ -204,6 +204,7 @@ int main (int argc,char *argv[])
 		   DEBUGPRINT("\n\nMain: evaluating 'main' section\n\n");
 		   if (Tcl_Eval(interp, "main") != TCL_OK) {
 			   fprintf(stderr,"Error when evaluating 'main' section of input script %s:\n%s\n",argv[1],Tcl_GetStringResult(interp));
+			   exit(1);
 		   }
 
 		    //simpson_fftw_test();


### PR DESCRIPTION
Just had a little quest when trying to catch cases of a wrong main section.
Since it is an error, it should return status!=0.

BTW: There seem to be other "errors" not dealt with in the main.c:
https://github.com/vosegaard/simpson/blob/master/main.c#L152